### PR TITLE
Use file hashes as IDs instead of random UUIDs (with migration support)

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -371,7 +371,7 @@ const settings = definePluginSettings({
 
                 const exportPayload = {
                     overrides,
-                    __note: "Audio files are not included in exports and will need to be re-uploaded after import"
+                    __note: "Audio files are not included in exports and will need to be re-uploaded before import"
                 };
 
                 const blob = new Blob([JSON.stringify(exportPayload, null, 2)], { type: "application/json" });


### PR DESCRIPTION
The usage of random UUIDs for files basically makes importing/exporting overrides useless the moment you want to make any kind of "sound pack" for other people to use, as they still have to manually upload ***and select*** each sound to replace.
Switching it for file hashes lets the plugin select uploaded files automatically.

The existing configurations can be easily updated by computing all file hashes at plugin start, which is now done in `migrateStorage()`.