### PR TITLE
Fix replacements for Discord verison stable 562538 (6acb41e)

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -208,9 +208,9 @@ export default definePlugin({
             find: "could not play audio",
             group: true,
             replacement: [
-                { match: /(let \i=class.{0,900}?new Audio;\i.src=)((\i\(\d+\))(?:\(`\.\/\$\{|.{0,50}concat\())this.name((?:\}\.mp3`|,".mp3"\))\))/, replace: '$3;$1this.type!=="discord"?this.audio:$2this.audio$4' },
+                { match: /(let \i=class.{0,1000}?new Audio;\i.src=)((\i\(\d+\))(?:\(`\.\/\$\{|.{0,50}concat\())this.name((?:\}\.mp3`|,".mp3"\))\))/, replace: '$3;$1this.type!=="discord"?this.audio:$2this.audio$4' },
                 { match: /(new Audio;)(\i)(\.src=)/, replace: '$1$2.crossOrigin="anonymous";$2$3' },
-                { match: /(?<=constructor\((\i,\i,\i,\i)).{0,200}outputChannel=\i/, replace: ",options){$self.buildPlayer(this,$1,options);" },
+                { match: /(?<=constructor\((\i,\i,\i,\i,\i)).{0,200}trackNotificationFailure=\i/, replace: ",options){$self.buildPlayer(this,$1,options);" },
                 { match: /(\i.pause\(\),(\i).src="".{0,20}?null)/, replace: "$2.onerror=()=>{},$1" },
                 { match: /(?<=(\i).onloadeddata=\(\)=>{)/, replace: "$self.applyBoost(this,$1)," }
             ]
@@ -225,7 +225,7 @@ export default definePlugin({
         }
     ],
 
-    buildPlayer(player: AudioPlayer, audio: string, _u: any, internalVolume: number, channel: string, options: any = {}) {
+    buildPlayer(player: AudioPlayer, audio: string, _u: any, internalVolume: number, channel: string, trackNotificationFailure: boolean, options: any = {}) {
         const v = Math.max(0, internalVolume || (options.volume ? options.volume / 100 : 1));
         player.preprocessDataOriginal = { audio, volume: v };
         player.audio = audio;
@@ -233,6 +233,7 @@ export default definePlugin({
         player._volume = Math.min(1, v);
         player.type = audioType(audio);
         (player as any).outputChannel = channel;
+        (player as any).trackNotificationFailure = trackNotificationFailure;
         (player as any).preload = false;
         (player as any).persistent = false;
         player.processAudio = () => this.processAudio(player);


### PR DESCRIPTION
Should close #23
<details><summary>Console output and new code</summary>
Error for "new Audio" replacement:

```
Logger.ts:40  Vencord   PluginManager  Starting plugin CustomSounds
Logger.ts:40  Vencord   WebpackPatcher  Patch by CustomSounds had no effect (Module id is 946261): /(let \i=class.{0,900}?new Audio;\i.src=)((\i\(\d+\))(?:\(`\.\/\$\{|.{0,50}concat\())this.name((?:\}\.mp3`|,".mp3"\))\))/
_log @ Logger.ts:40
Logger.ts:40  Vencord   WebpackPatcher  Undoing patch group could not play audio by CustomSounds because replacement /(let \i=class.{0,900}?new Audio;\i.src=)((\i\(\d+\))(?:\(`\.\/\$\{|.{0,50}concat\())this.name((?:\}\.mp3`|,".mp3"\))\))/ had no effect
_log @ Logger.ts:40
```

Error for "buildPlayer" replacement:

```
Logger.ts:40  Vencord   PluginManager  Starting plugin CustomSounds
Logger.ts:40  Vencord   WebpackPatcher  Patch by CustomSounds errored (Module id is 946261): /(?<=constructor\((\i,\i,\i,\i)).{0,200}outputChannel=\i/
 SyntaxError: Unexpected token ','
    at eval (<anonymous>)
    at IS (patchWebpack.ts:600:38)
    at Object.apply (patchWebpack.ts:263:32)
    at A (web.7a8cf81b22dd8f50.js:217:1418286)
    at 400492 (web.7a8cf81b22dd8f50.js:148:20607)
    at bS (patchWebpack.ts:418:40)
    at Object.apply (patchWebpack.ts:264:16)
    at A (web.7a8cf81b22dd8f50.js:217:1418286)
    at 827343 (web.7a8cf81b22dd8f50.js:12:2078369)
    at bS (patchWebpack.ts:418:40)
_log @ Logger.ts:40
Logger.ts:40  Vencord   WebpackPatcher  Undoing patch group could not play audio by CustomSounds because replacement /(?<=constructor\((\i,\i,\i,\i)).{0,200}outputChannel=\i/ errored
_log @ Logger.ts:40
```

New code from Discord:

```js
let T = class {
	name;
	_volume;
	_audio;
	outputChannel;
	trackNotificationFailure;
	constructor(e, t, n, i, r=!1) {
			this.name = e,
			this._volume = n,
			this.outputChannel = i,
			this.trackNotificationFailure = r
	}
	get volume() {
			return this._volume
	}
```
</details>