### PR TITLE
Fix crash when opening settings after a custom sound file goes missing

### DIFF
--- a/audio.ts
+++ b/audio.ts
@@ -195,7 +195,12 @@ function dataUriToArrayBuffer(dataUri: string): ArrayBuffer | null {
 }
 
 export async function getAllAudio(): Promise<Record<string, StoredAudioFile>> {
-    return (await get(KEY)) ?? {};
+    try {
+        return (await get(KEY)) ?? {};
+    } catch (e) {
+        console.error("[CustomSounds] Failed to read audio store:", e);
+        return {};
+    }
 }
 
 export async function getAudioMeta(): Promise<Record<string, string>> {

--- a/index.tsx
+++ b/index.tsx
@@ -138,7 +138,9 @@ function SettingsUI() {
     }, []);
 
     React.useEffect(() => {
-        soundTypes.forEach(t => { if (!settings.store[t.id]) setOverride(t.id, makeEmptyOverride()); });
+        try {
+            soundTypes.forEach(t => { if (!settings.store[t.id]) setOverride(t.id, makeEmptyOverride()); });
+        } catch (e) { console.error("[CustomSounds]", e); }
         loadFiles();
     }, []);
 

--- a/index.tsx
+++ b/index.tsx
@@ -120,7 +120,21 @@ function SettingsUI() {
     const fileInputRef = React.useRef<HTMLInputElement>(null);
 
     const loadFiles = React.useCallback(async () => {
-        try { setFiles(await getAudioMeta()); } catch (e) { console.error("[CustomSounds]", e); }
+        try {
+            const meta = await getAudioMeta();
+            setFiles(meta);
+            let healed = false;
+            for (const t of soundTypes) {
+                const o = getOverride(t.id);
+                if (o.selectedSound === "custom" && o.selectedFileId && !meta[o.selectedFileId]) {
+                    o.selectedFileId = undefined;
+                    o.selectedSound = "default";
+                    setOverride(t.id, o);
+                    healed = true;
+                }
+            }
+            if (healed) setResetTrigger(t => t + 1);
+        } catch (e) { console.error("[CustomSounds]", e); }
     }, []);
 
     React.useEffect(() => {


### PR DESCRIPTION
Fixes #25

Crashing Equicord when trying to access plugin's settings. It was normal until I wanted to add a new sound, I've put a custom .wav sound on Call Ringing and accidentally deleted the source file from my Downloads folder. After that, opening CustomSounds settings crashed my Equicord every time.

I fixed it myself for now by exporting my DataStore backup (Equicord Settings - Backup & Restore), cleaning the ScattrdCustomSounds entry manually, and importing it back. That got me unblocked, but the actual bug is still in the code nothing in audio.ts or index.tsx handles a broken/missing audio entry, so any override left pointing at a file that no longer exists in the store takes the whole settings panel down instead of just falling back to default.

This PR adds that missing error handling
- getAllAudio() in audio.ts now wraps the DataStore.get() call in try/catch so a failed read doesn't throw uncaught.
- SettingsUI in index.tsx now checks, on every load, whether each override's selectedFileId actually exists in the audio store. If it doesn't, it resets that override back to default instead of leaving a dangling reference around.

With this in, the same situation (upload didn't fully save, file got deleted, storage got corrupted, whatever) just silently resets to default instead of crashing the client.

Will be sent to Equicord's plugin implementation too